### PR TITLE
NFC: Upgrade to python3

### DIFF
--- a/scheduler_test.py
+++ b/scheduler_test.py
@@ -100,5 +100,5 @@ schedule.addOngoings(ongoings)
 schedule.makeSchedule()
 
 
-print schedule
-print LpStatus[schedule.makeSchedule().status]
+print(schedule)
+print(LpStatus[schedule.makeSchedule().status])


### PR DESCRIPTION
This PR should have no functional changes. Please see the below example output and confirm.

```
$ python3 scheduler_test.py 
Saturday 2018-09-29
task1 2:3.00
task2 0:1.55
task4 0:1.88
task5 0:3.11
task6 0:4.55
task9 0:2.00
task15 3:3.00
task16 1:3.00
score totals: 426 199 43 0 29 385 
total time: 9:3.99

Sunday 2018-09-30
task3 0:1.55
task4 1:5.11
task5 2:5.99
task8 0:3.00
task11 2:3.44
task16 1:3.00
score totals: 500 199 53 0 96 219 
total time: 9:3.99

Monday 2018-10-01
task4 1:4.99
task5 2:2.99
task8 0:3.00
task10 4:1.99
task16 0:3.00
score totals: 443 199 51 0 141 149 
total time: 9:3.99

Tuesday 2018-10-02
task7 1:1.55
task8 0:3.00
task10 0:4.00
task11 6:0.00
score totals: 194 162 50 0 200 255 
total time: 8:2.55

Wednesday 2018-10-03
task7 1:1.55
task8 0:3.00
task10 0:4.00
task11 6:0.00
score totals: 194 162 50 0 200 255 
total time: 8:2.55

Thursday 2018-10-04
task7 1:1.55
task8 0:3.00
task10 0:4.00
task11 6:0.00
score totals: 194 162 50 0 200 255 
total time: 8:2.55

Friday 2018-10-05
task7 1:1.55
task8 0:3.00
task10 0:4.00
task11 6:0.00
score totals: 194 162 50 0 200 255 
total time: 8:2.55


Optimal
```