### PR TITLE
Add MIT license for current repository

### DIFF
--- a/old_java/LICENSE
+++ b/old_java/LICENSE
@@ -1,6 +1,9 @@
+This repository makes use of Nils Löhndorf's Java interface to the CLP Linear Solver,
+which was released under the following license:
+
 The MIT License (MIT)
 
-Copyright (c) 2018
+Copyright (c) 2016 Nils Löhndorf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The old MIT license was for acknowledging the CLP linear solver that is no longer used.
I've moved that to the old_java folder.
I've added a new generic MIT license to show that any code in this repository is open for anyone to use.